### PR TITLE
Remove duplicate migrate command from startCommand to prevent

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -3,7 +3,7 @@ services:
     name: c3-app
     runtime: python
     buildCommand: "./build.sh"
-    startCommand: "python manage.py migrate && gunicorn c3_app.wsgi:application --bind 0.0.0.0:$PORT"
+    startCommand: "gunicorn c3_app.wsgi:application --bind 0.0.0.0:$PORT"
     envVars:
       - key: PYTHON_VERSION
         value: 3.11.0


### PR DESCRIPTION
   migration conflicts. Migration now runs only once in buildCommand
   with --fake-initial flag to handle existing database objects.

   Changes:
   - Remove 'python manage.py migrate' from render.yaml startCommand
   - Keep migrate --fake-initial in build.sh buildCommand only