### PR TITLE
Fix deployment migration and superuser creation issuesC

### DIFF
--- a/config/management/commands/create_admin_in_deploy.py
+++ b/config/management/commands/create_admin_in_deploy.py
@@ -9,27 +9,27 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         User = get_user_model()
 
-        username = os.environ.get("DJANGO_SUPERUSER_USERNAME")
+        user_id = os.environ.get("DJANGO_SUPERUSER_USER_ID")
         password = os.environ.get("DJANGO_SUPERUSER_PASSWORD")
         email = os.environ.get("DJANGO_SUPERUSER_EMAIL", "")
 
-        if not username or not password:
+        if not user_id or not password:
             self.stdout.write(
                 self.style.WARNING(
-                    "DJANGO_SUPERUSER_USERNAME and DJANGO_SUPERUSER_PASSWORD must be set"
+                    "DJANGO_SUPERUSER_USER_ID and DJANGO_SUPERUSER_PASSWORD must be set"
                 )
             )
             return
 
-        if User.objects.filter(username=username).exists():
+        if User.objects.filter(user_id=user_id).exists():
             self.stdout.write(
-                self.style.WARNING(f"Superuser '{username}' already exists.")
+                self.style.WARNING(f"Superuser '{user_id}' already exists.")
             )
             return
 
         User.objects.create_superuser(
-            username=username, email=email, password=password
+            user_id=user_id, email=email, password=password
         )
         self.stdout.write(
-            self.style.SUCCESS(f"Superuser '{username}' created successfully.")
+            self.style.SUCCESS(f"Superuser '{user_id}' created successfully.")
         )

--- a/render.yaml
+++ b/render.yaml
@@ -25,7 +25,7 @@ services:
         value: 5432
       - key: CSRF_TRUSTED_ORIGINS
         sync: false
-      - key: DJANGO_SUPERUSER_USERNAME
+      - key: DJANGO_SUPERUSER_USER_ID
         sync: false
       - key: DJANGO_SUPERUSER_PASSWORD
         sync: false


### PR DESCRIPTION
 - Remove duplicate migrate command from startCommand to prevent conflicts
   - Add --fake-initial flag to handle existing database objects
   - Update create_admin_in_deploy command to use user_id instead of username
   - Rename DJANGO_SUPERUSER_USERNAME to DJANGO_SUPERUSER_USER_ID

   Changes:
   - build.sh: Keep migrate --fake-initial in buildCommand only
   - render.yaml: Remove migrate from startCommand, rename env var
   - create_admin_in_deploy.py: Use user_id field for custom user model