### PR TITLE
掲示板詳細表示機能の追加

### DIFF
--- a/bbs/views.py
+++ b/bbs/views.py
@@ -61,6 +61,7 @@ def bbs_detail(request, bbs_id):
 
     # ベストアンサーを先頭に、その他を時系列順にソート
     # Pythonでは False < True なので、False（ベストアンサー）が先に来る
+    
     mock_comments = sorted(all_comments, key=lambda x: (not x['is_best_answer'], x['created_at']))
 
     context = {


### PR DESCRIPTION
prを通さずにマージしてしまったので、形上のpr

close #19 

## やったこと
掲示板の詳細表示機能を実装した。
掲示板一覧ページから対処の掲示板を選択すると、詳細ページ飛べる。
コメントはモックで実現しているので、ほかのissueで実装すること
