### PR TITLE
掲示板へのコメント機能追加

### DIFF
--- a/bbs/forms.py
+++ b/bbs/forms.py
@@ -1,5 +1,5 @@
 from django import forms
-from .models import BBSPost
+from .models import BBSPost, BBSComment
 
 
 class BBSPostForm(forms.ModelForm):
@@ -40,3 +40,25 @@ class BBSPostForm(forms.ModelForm):
         
         # reportフィールドを任意にする
         self.fields['report'].required = False
+
+class BBSCommentForm(forms.ModelForm):
+    """掲示板コメントフォーム"""
+
+    class Meta:
+        model = BBSComment
+        fields = ['content']
+        widgets = {
+            'content': forms.Textarea(attrs={
+                'class': 'form-control',
+                'placeholder': 'コメントを入力してください',
+                'rows': 3,
+                'required': True
+            }),
+        }
+        labels = {
+            'content': '',
+        }
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.fields['content'].required = True

--- a/bbs/templates/bbs/detail.html
+++ b/bbs/templates/bbs/detail.html
@@ -93,27 +93,50 @@
                 {% endfor %}
             </div>
 
-            <!-- コメント入力フォーム（モック） -->
+            <!-- コメント入力フォーム -->
             <div class="border-t border-gray-200 pt-6">
                 <h3 class="font-semibold text-gray-800 mb-3">コメントを投稿</h3>
-                <form class="space-y-4">
-                    <textarea
-                        class="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-transparent resize-none"
-                        rows="4"
-                        placeholder="コメントを入力してください"
-                        disabled
-                    ></textarea>
+                <form method="post" action="{% url 'bbs:comment' post.post_id %}" class="space-y-4" id="commentForm">
+                    {% csrf_token %}
+
+                    {{ comment_form.as_p }}
                     <div class="flex justify-end">
                         <button
-                            type="button"
-                            class="bg-gray-400 text-white font-medium py-2 px-6 rounded-lg cursor-not-allowed"
+                            type="submit"
+                            id="submitButton"
+                            class="bg-gray-400 text-white font-medium py-2 px-6 rounded-lg cursor-not-allowed transition-colors duration-200"
                             disabled
                         >
-                            送信（コメント機能は未実装）
+                            送信
                         </button>
                     </div>
                 </form>
             </div>
+
+            <script>
+                document.addEventListener('DOMContentLoaded', function() {
+                    const form = document.getElementById('commentForm');
+                    const textarea = form.querySelector('textarea');
+                    const submitButton = document.getElementById('submitButton');
+
+                    function updateButtonState() {
+                        const hasContent = textarea.value.trim().length > 0;
+
+                        if (hasContent) {
+                            submitButton.disabled = false;
+                            submitButton.classList.remove('bg-gray-400', 'cursor-not-allowed');
+                            submitButton.classList.add('bg-primary', 'hover:bg-primary-dark', 'cursor-pointer');
+                        } else {
+                            submitButton.disabled = true;
+                            submitButton.classList.remove('bg-primary', 'hover:bg-primary-dark', 'cursor-pointer');
+                            submitButton.classList.add('bg-gray-400', 'cursor-not-allowed');
+                        }
+                    }
+
+                    textarea.addEventListener('input', updateButtonState);
+                    updateButtonState();
+                });
+            </script>
         </div>
     </div>
 </div>

--- a/bbs/urls.py
+++ b/bbs/urls.py
@@ -8,4 +8,5 @@ urlpatterns = [
     path('list/', views.bbs_list, name='list'),
     path('register/', views.bbs_register, name='register'),
     path('detail/<int:bbs_id>/', views.bbs_detail, name='detail'),
+    path('<int:bbs_id>/comment/', views.bbs_comment, name='comment'),
 ]


### PR DESCRIPTION
close #20 

## やったこと
掲示板一覧画面から、その掲示板についてコメントできる機能を追加した。
コメント入力欄が空の場合はsubmitボタンが押せないように`bb/detail.html`内のjsで制御している。
コメント送信後は詳細画面にリダイレクトし、コメント欄に即座に反映するようにした。

## 動作確認手順
`/bbs/list/`で任意の掲示板を選択し、詳細画面でコメントを送信する。