### PR TITLE
Renderスピンダウン対策

### DIFF
--- a/c3_app/urls.py
+++ b/c3_app/urls.py
@@ -26,4 +26,5 @@ urlpatterns = [
     path('bbs/', include('bbs.urls')),
     path('analysis/', include('analytics.urls')),
     path('ai/', include('ai_features.urls')),
+
 ]

--- a/common/urls.py
+++ b/common/urls.py
@@ -5,4 +5,6 @@ app_name = 'common'
 
 urlpatterns = [
     path('', views.index, name='index'),
+
+    path('health/', views.health, name="health"),
 ]

--- a/common/views.py
+++ b/common/views.py
@@ -1,5 +1,6 @@
 from django.shortcuts import render
 from django.contrib.auth.decorators import login_required
+from django.http import HttpResponse
 
 @login_required
 def index(request):
@@ -7,3 +8,10 @@ def index(request):
     ホーム画面を表示する
     """
     return render(request, 'common/index.html')
+
+def health(request):
+    """
+    health end point
+    """
+
+    return HttpResponse(status=200)


### PR DESCRIPTION
close #71 

## やったこと

health check viewを追加（`common`アプリ）
URL：`/health/`

## スピンダウン対策
無料版のRenderは15分間アクセスが無いとスピンダウン（待機状態になる）してしまう。
これは、可用性に大きく影響するので、その対策としてGoogleAppScriptのトリガーを用いて定期的にアクセスすることで回避することとした。

### GAS コード
```
function pingRender() {
  const url = "https://c3-ekeu.onrender.com/health/";
  try {
    const res = UrlFetchApp.fetch(url, {
      method: "get",
      muteHttpExceptions: true,
    });
    console.log(`status: ${res.getResponseCode()}`);
  } catch (e) {
    console.error(e);
  }
}
```