### PR TITLE
日報一覧機能追加

### DIFF
--- a/c3_app/settings.py
+++ b/c3_app/settings.py
@@ -48,6 +48,7 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    'django.contrib.humanize',
     # Custom apps
     'config',
     'accounts',

--- a/common/templates/common/components/bottom_nav.html
+++ b/common/templates/common/components/bottom_nav.html
@@ -3,6 +3,20 @@
 
     {% with current=request.resolver_match.view_name %}
 
+    <!-- 日報 -->
+    <a href="{% url 'reports:list' %}"
+       class="flex flex-col items-center gap-1
+       {% if current == 'reports:list' %}
+         text-primary
+       {% else %}
+         text-gray-400 hover:text-primary
+       {% endif %}">
+      <svg class="w-6 h-6" fill="currentColor" viewBox="0 0 24 24">
+        <path d="M16 4h-1.2A3 3 0 0 0 12 2a3 3 0 0 0-2.8 2H8a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h8a2 2 0 0 0 2-2V6a2 2 0 0 0-2-2zm-4-1a1 1 0 0 1 1 1h-2a1 1 0 0 1 1-1z"/>
+      </svg>
+      <span>日報</span>
+    </a>
+
     <!-- 分析 -->
     <a href="{% url 'analytics:dashboard' %}"
        class="flex flex-col items-center gap-1
@@ -98,16 +112,6 @@
       <div class="h-px bg-gray-200 my-4"></div>
 
       <div class="grid grid-cols-3 gap-x-10 gap-y-10 justify-items-center">
-
-        <!-- リスト機能 -->
-        <a href="/list" data-drawer-close="1" class="flex flex-col items-center gap-3">
-          <div class="w-24 h-24 rounded-2xl bg-teal-100 flex items-center justify-center">
-            <svg class="w-10 h-10 text-gray-600" viewBox="0 0 24 24" fill="currentColor">
-              <path d="M16 4h-1.2A3 3 0 0 0 12 2a3 3 0 0 0-2.8 2H8a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h8a2 2 0 0 0 2-2V6a2 2 0 0 0-2-2zm-4-1a1 1 0 0 1 1 1h-2a1 1 0 0 1 1-1z"/>
-            </svg>
-          </div>
-          <span class="text-gray-700">リスト機能</span>
-        </a>
 
         <!-- ユーザー情報 -->
         <a href="/accounts/profile" data-drawer-close="1" class="flex flex-col items-center gap-3">

--- a/common/templates/common/index.html
+++ b/common/templates/common/index.html
@@ -38,7 +38,7 @@
         </div>
     </div>
 
-    <a href="/report/register/" class="fixed bottom-24 right-6 bg-white rounded-full p-2 shadow-xl z-20 flex flex-col items-center justify-center w-20 h-20 border-4 border-white">
+    <a href="{% url 'reports:register' %}?next={% url 'common:index' %}" class="fixed bottom-24 right-6 bg-white rounded-full p-2 shadow-xl z-20 flex flex-col items-center justify-center w-20 h-20 border-4 border-white">
         <span class="text-3xl text-gray-700">📝</span>
         <span class="text-[10px] font-bold text-gray-600">日報登録</span>
     </a>

--- a/reports/templates/reports/list.html
+++ b/reports/templates/reports/list.html
@@ -1,0 +1,316 @@
+{% extends 'base.html' %}
+{% load humanize %}
+
+{% block title %}日報一覧 - C3 ステリコットα{% endblock %}
+
+{% block content %}
+<div class="min-h-screen py-8 px-4">
+    <div class="max-w-6xl mx-auto">
+        <div class="bg-white rounded-lg shadow-md p-6">
+
+            <div class="flex justify-between items-center mb-6">
+                <h1 class="text-2xl font-bold text-gray-800">日報一覧</h1>
+                <a href="{% url 'reports:register' %}?next={% url 'reports:list' %}" class="bg-teal-600 hover:bg-teal-700 text-white font-medium py-2 px-4 rounded-lg transition duration-200">
+                    新規作成
+                </a>
+            </div>
+
+            <!-- タブナビゲーション -->
+            <div class="mb-6 border-b border-gray-200">
+                <nav class="flex gap-4" role="tablist">
+                    <button type="button" id="tab-daily" onclick="switchTab('daily')"
+                            class="tab-button px-4 py-2 font-medium text-sm border-b-2 transition-colors duration-200 border-teal-600 text-teal-600">
+                        日別表示
+                    </button>
+                    <button type="button" id="tab-search" onclick="switchTab('search')"
+                            class="tab-button px-4 py-2 font-medium text-sm border-b-2 transition-colors duration-200 border-transparent text-gray-500 hover:text-gray-700">
+                        検索表示
+                    </button>
+                </nav>
+            </div>
+
+            <!-- 日別表示タブ -->
+            <div id="content-daily" class="tab-content">
+                {% if reports_by_date %}
+                    <div class="space-y-4">
+                    {% for day_data in reports_by_date %}
+                        <div class="border border-gray-200 rounded-lg overflow-hidden">
+                            <!-- 日付カード（クリック可能） -->
+                            <button type="button"
+                                    onclick="toggleDayAccordion('day-{{ forloop.counter }}')"
+                                    class="w-full flex items-center justify-between p-4 bg-white hover:bg-gray-50 transition duration-200">
+                                <div class="flex items-center gap-4">
+                                    <div class="text-left">
+                                        <h2 class="text-xl font-bold text-gray-800">
+                                            {{ day_data.date|date:"Y年m月d日 (D)" }}
+                                        </h2>
+                                    </div>
+                                    <span class="text-sm bg-teal-100 text-teal-700 px-3 py-1 rounded-full font-medium">
+                                        {{ day_data.count }}件
+                                    </span>
+                                </div>
+                                <svg id="icon-day-{{ forloop.counter }}"
+                                     class="w-6 h-6 text-gray-400 transform transition-transform duration-200"
+                                     fill="none"
+                                     stroke="currentColor"
+                                     viewBox="0 0 24 24">
+                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/>
+                                </svg>
+                            </button>
+
+                            <!-- その日の日報一覧（最初は非表示） -->
+                            <div id="day-{{ forloop.counter }}" class="accordion-content hidden bg-gray-50 border-t border-gray-200">
+                                <div class="p-4 space-y-3">
+
+                                    <!-- 売上情報セクション -->
+                                    {% if day_data.performance %}
+                                    <div class="bg-white border border-teal-200 rounded-lg p-4 mb-4">
+                                        <h3 class="text-sm font-semibold text-teal-700 mb-3">店舗実績</h3>
+                                        <div class="grid grid-cols-3 gap-4">
+                                            <div class="text-center">
+                                                <p class="text-xs text-gray-500 mb-1">売上金額</p>
+                                                <p class="text-xl font-bold text-gray-800">¥{{ day_data.performance.sales_amount|intcomma|default:"--" }}</p>
+                                            </div>
+                                            <div class="text-center">
+                                                <p class="text-xs text-gray-500 mb-1">客数</p>
+                                                <p class="text-xl font-bold text-gray-800">{{ day_data.performance.customer_count|intcomma|default:"--" }}<span class="text-sm text-gray-500">人</span></p>
+                                            </div>
+                                            <div class="text-center">
+                                                <p class="text-xs text-gray-500 mb-1">違算金額</p>
+                                                <p class="text-xl font-bold {% if day_data.performance.cash_difference == 0 %}text-green-600{% else %}text-red-600{% endif %}">
+                                                    {% if day_data.performance.cash_difference > 0 %}+{% endif %}¥{{ day_data.performance.cash_difference|intcomma|default:"--" }}
+                                                </p>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    {% else %}
+                                    <div class="bg-yellow-50 border border-yellow-200 rounded-lg p-3 mb-4">
+                                        <p class="text-sm text-yellow-800 text-center">この日の店舗実績データは未登録です</p>
+                                    </div>
+                                    {% endif %}
+
+                                    <!-- 日報一覧 -->
+                                {% for report in day_data.reports %}
+                                    <a href="{% url 'reports:view' report.report_id %}"
+                                       class="block border border-gray-200 rounded-lg p-3 hover:shadow-md hover:border-teal-500 transition duration-200 bg-white">
+
+                                        <div class="flex items-start justify-between gap-4">
+                                            <div class="flex-1">
+                                                <div class="flex items-center gap-2 mb-2">
+                                                    <span class="text-xs font-semibold bg-gray-100 text-gray-600 px-2 py-1 rounded">
+                                                        {{ report.get_genre_display }}
+                                                    </span>
+                                                    <span class="text-xs font-semibold bg-blue-100 text-blue-600 px-2 py-1 rounded">
+                                                        {{ report.get_location_display }}
+                                                    </span>
+                                                    {% if report.post_to_bbs %}
+                                                        <span class="text-xs bg-teal-100 text-teal-700 px-2 py-1 rounded">掲示板連携</span>
+                                                    {% endif %}
+                                                </div>
+
+                                                <h3 class="text-lg font-semibold text-gray-800 mb-1">
+                                                    {{ report.title }}
+                                                </h3>
+
+                                                <p class="text-gray-700 text-sm mb-2 line-clamp-2">
+                                                    {{ report.content|truncatechars:100 }}
+                                                </p>
+
+                                                <div class="flex items-center gap-3 text-sm text-gray-500">
+                                                    <span>{{ report.user.username }}</span>
+                                                    <span>{{ report.created_at|date:"H:i" }}</span>
+                                                </div>
+                                            </div>
+                                        </div>
+
+                                    </a>
+                                {% endfor %}
+                                </div>
+                            </div>
+                        </div>
+                    {% endfor %}
+                    </div>
+                {% else %}
+                    <div class="text-center py-12">
+                        <p class="text-gray-600 text-lg">まだ日報がありません</p>
+                        <p class="text-gray-500 mt-2">最初の日報を作成してみましょう</p>
+                    </div>
+                {% endif %}
+            </div>
+
+            <!-- 検索表示タブ -->
+            <div id="content-search" class="tab-content hidden">
+                <div class="mb-6 bg-gray-50 p-4 rounded-lg border border-gray-200">
+                    <form method="get" action="" class="space-y-3">
+                        <input type="hidden" name="view" value="search">
+                        <div class="flex gap-2">
+                            <input type="text" name="query" value="{{ query|default:'' }}"
+                                   placeholder="キーワードを入力（デフォルトではor検索）"
+                                   class="flex-1 border border-gray-300 rounded-lg px-4 py-2 focus:outline-none focus:ring-2 focus:ring-teal-500 text-sm">
+                            <button type="submit" class="bg-teal-600 text-white font-bold px-6 py-2 rounded-lg text-sm shadow hover:bg-teal-700 transition duration-200">
+                                検索
+                            </button>
+                        </div>
+
+                        <div class="flex gap-2">
+                            <div class="relative w-1/3">
+                                <select name="genre" onchange="this.form.submit()"
+                                        class="w-full appearance-none bg-white border border-gray-300 text-gray-700 py-2 px-3 pr-8 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-teal-500">
+                                    <option value="">全てのジャンル</option>
+                                    {% for code, label in genre_choices %}
+                                        <option value="{{ code }}" {% if current_genre == code %}selected{% endif %}>
+                                            {{ label }}
+                                        </option>
+                                    {% endfor %}
+                                </select>
+                                <div class="pointer-events-none absolute inset-y-0 right-0 flex items-center px-2 text-gray-500">
+                                    <svg class="fill-current h-4 w-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M9.293 12.95l.707.707L15.657 8l-1.414-1.414L10 10.828 5.757 6.586 4.343 8z"/></svg>
+                                </div>
+                            </div>
+
+                            <div class="relative w-1/3">
+                                <select name="location" onchange="this.form.submit()"
+                                        class="w-full appearance-none bg-white border border-gray-300 text-gray-700 py-2 px-3 pr-8 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-teal-500">
+                                    <option value="">全ての場所</option>
+                                    {% for code, label in location_choices %}
+                                        <option value="{{ code }}" {% if current_location == code %}selected{% endif %}>
+                                            {{ label }}
+                                        </option>
+                                    {% endfor %}
+                                </select>
+                                <div class="pointer-events-none absolute inset-y-0 right-0 flex items-center px-2 text-gray-500">
+                                    <svg class="fill-current h-4 w-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M9.293 12.95l.707.707L15.657 8l-1.414-1.414L10 10.828 5.757 6.586 4.343 8z"/></svg>
+                                </div>
+                            </div>
+
+                            <div class="relative w-1/3">
+                                <select name="sort" onchange="this.form.submit()"
+                                        class="w-full appearance-none bg-white border border-gray-300 text-gray-700 py-2 px-3 pr-8 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-teal-500">
+                                    <option value="newest" {% if sort == 'newest' %}selected{% endif %}>日付: 新しい順</option>
+                                    <option value="oldest" {% if sort == 'oldest' %}selected{% endif %}>日付: 古い順</option>
+                                </select>
+                                <div class="pointer-events-none absolute inset-y-0 right-0 flex items-center px-2 text-gray-500">
+                                    <svg class="fill-current h-4 w-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M9.293 12.95l.707.707L15.657 8l-1.414-1.414L10 10.828 5.757 6.586 4.343 8z"/></svg>
+                                </div>
+                            </div>
+                        </div>
+                    </form>
+                </div>
+
+                {% if reports %}
+                    <div class="space-y-4">
+                    {% for report in reports %}
+                        <a href="{% url 'reports:view' report.report_id %}"
+                           class="block border border-gray-200 rounded-lg p-4 hover:shadow-md hover:border-teal-500 transition duration-200">
+
+                            <div class="flex flex-wrap items-center justify-between gap-4 pt-2 border-t border-gray-100 mt-2">
+
+                                <div class="flex items-center gap-2">
+                                    <span class="text-xs font-semibold bg-gray-100 text-gray-600 px-2 py-1 rounded">
+                                        {{ report.get_genre_display }}
+                                    </span>
+                                    <span class="text-xs font-semibold bg-blue-100 text-blue-600 px-2 py-1 rounded">
+                                        {{ report.get_location_display }}
+                                    </span>
+                                    <h2 class="text-xl font-semibold text-gray-800">
+                                        {{ report.title }}
+                                    </h2>
+                                </div>
+
+                                <span class="text-sm text-gray-500 whitespace-nowrap">
+                                    {{ report.date|date:"Y/m/d" }}
+                                </span>
+                            </div>
+
+                            <div class="mb-3 mt-2">
+                                <p class="text-gray-700 line-clamp-2 text-sm">
+                                    {{ report.content|truncatechars:100 }}
+                                </p>
+                            </div>
+
+                            <div class="flex items-center justify-between text-sm text-gray-500">
+                                <div class="flex items-center gap-4">
+
+                                    <div class="flex items-center gap-1">
+                                        <span>{{ report.user.username }}</span>
+                                    </div>
+
+                                    <div class="flex items-center gap-1">
+                                        <span>{{ report.store.store_name }}</span>
+                                    </div>
+
+                                    {% if report.post_to_bbs %}
+                                        <div class="flex items-center gap-1">
+                                            <span class="text-xs bg-teal-100 text-teal-700 px-2 py-1 rounded">掲示板連携</span>
+                                        </div>
+                                    {% endif %}
+                                </div>
+                            </div>
+
+                        </a>
+                    {% endfor %}
+                </div>
+
+                {% else %}
+                    <div class="text-center py-12">
+                        <p class="text-gray-600 text-lg">まだ日報がありません</p>
+                        <p class="text-gray-500 mt-2">最初の日報を作成してみましょう</p>
+                    </div>
+                {% endif %}
+            </div>
+
+        </div>
+    </div>
+</div>
+
+<script>
+// タブ切り替え機能
+function switchTab(tabName) {
+    // すべてのタブボタンを非アクティブに
+    document.querySelectorAll('.tab-button').forEach(btn => {
+        btn.classList.remove('border-teal-600', 'text-teal-600');
+        btn.classList.add('border-transparent', 'text-gray-500');
+    });
+
+    // すべてのタブコンテンツを非表示に
+    document.querySelectorAll('.tab-content').forEach(content => {
+        content.classList.add('hidden');
+    });
+
+    // 選択されたタブをアクティブに
+    const activeTabBtn = document.getElementById(`tab-${tabName}`);
+    activeTabBtn.classList.remove('border-transparent', 'text-gray-500');
+    activeTabBtn.classList.add('border-teal-600', 'text-teal-600');
+
+    // 選択されたタブコンテンツを表示
+    const activeContent = document.getElementById(`content-${tabName}`);
+    activeContent.classList.remove('hidden');
+
+    // タブの状態をlocalStorageに保存
+    localStorage.setItem('reportsActiveTab', tabName);
+}
+
+// アコーディオンの展開/折りたたみ機能
+function toggleDayAccordion(dayId) {
+    const content = document.getElementById(dayId);
+    const icon = document.getElementById(`icon-${dayId}`);
+
+    if (content.classList.contains('hidden')) {
+        // 展開
+        content.classList.remove('hidden');
+        icon.classList.add('rotate-180');
+    } else {
+        // 折りたたみ
+        content.classList.add('hidden');
+        icon.classList.remove('rotate-180');
+    }
+}
+
+// ページロード時にタブの状態を復元
+document.addEventListener('DOMContentLoaded', function() {
+    const savedTab = localStorage.getItem('reportsActiveTab') || 'daily';
+    switchTab(savedTab);
+});
+</script>
+
+{% endblock %}

--- a/reports/templates/reports/register.html
+++ b/reports/templates/reports/register.html
@@ -90,7 +90,7 @@
 
                 <!-- ボタン -->
                 <div class="flex justify-between pt-4">
-                    <a href="{% url 'common:index' %}" class="px-6 py-2 border border-gray-300 rounded-lg text-gray-700 hover:bg-gray-50 transition">
+                    <a href="{{ request.GET.next|default:'/' }}" class="px-6 py-2 border border-gray-300 rounded-lg text-gray-700 hover:bg-gray-50 transition">
                         キャンセル
                     </a>
                     <button type="submit" class="px-6 py-2 bg-primary hover:bg-primary-dark text-white rounded-lg transition">

--- a/reports/templates/reports/view.html
+++ b/reports/templates/reports/view.html
@@ -7,8 +7,8 @@
     <div class="max-w-4xl mx-auto">
         <!-- Header -->
         <div class="mb-6">
-            <a href="{% url 'common:index' %}" class="text-primary hover:text-primary-dark mb-4 inline-block">
-                &larr; Back to Home
+            <a href="{% url 'reports:list' %}" class="text-primary hover:text-primary-dark mb-4 inline-block">
+                &larr; 日報一覧に戻る
             </a>
             <h1 class="text-3xl font-bold text-gray-900">Daily Report</h1>
         </div>

--- a/reports/urls.py
+++ b/reports/urls.py
@@ -7,4 +7,5 @@ app_name = 'reports'
 urlpatterns = [
     path('register/', views.report_register, name='register'),
     path('view/<int:report_id>/', views.report_view, name='view'),
+    path('list/', views.report_list, name='list'),
 ]


### PR DESCRIPTION
close #103 

## やったこと
- ボトムナビに日報一覧機能へのナビゲーションを追加
- 日報一覧画面を追加（日別の表示＝その日のその店舗の日報、検索表示＝その店舗の日報）
- ホーム画面のフロートボタンから日報登録画面に飛んだ際のキャンセルボタンのリンクと日報一覧画面から日報登録に飛んだ際のキャンセルボタンのリンクはそれぞれ、ホーム画面と日報一覧画面になるように動的に調整