### PR TITLE
[fix]目標更新時の不要なメッセージ表示を削除

### DIFF
--- a/stores/views.py
+++ b/stores/views.py
@@ -34,7 +34,9 @@ def update_current_month_goal(request):
         form = MonthlyGoalForm(request.POST, instance=goal_obj)
         if form.is_valid():
             form.save()
-            messages.success(request, f"{today.year}年{today.month}月の店舗目標を更新しました。")
+            # ▼▼▼ 修正：メッセージ表示を削除（どこにも表示させないため） ▼▼▼
+            # messages.success(...) の行を削除しました
+            
             # 保存後はホームへ
             return redirect('common:index')
     else:


### PR DESCRIPTION
close #124

## 背景
店舗目標を更新した際にセットされる「更新完了メッセージ」を表示する場所がホーム画面になかったため、メッセージが裏側で保持され続け、次にメッセージ表示機能を持つ画面（日報登録画面など）を開いた際に遅れて表示されてしまうバグを修正しました。

今回は「更新時の通知メッセージ自体が不要」との判断に基づき、メッセージの生成処理自体を削除することで対応しました。

## やったこと
* **`stores/views.py` の修正**:
    * `update_current_month_goal` ビュー内の `messages.success()` の行を削除。
    * これにより、目標更新後に不要なメッセージがキューに溜まらないようにし、他画面での誤表示を防止しました。

## 動作確認方法
1. 店長（Manager）アカウントでログインし、店舗目標を編集・保存する。
2. ホーム画面へリダイレクトされることを確認。
3. その後、右下の「日報登録」ボタンを押し、日報登録画面へ遷移する。
4. 画面上部に「店舗目標を更新しました」というメッセージが表示されないことを確認。