### PR TITLE
[fix]スタッフ管理一覧のスマホ表示（横スクロール）対応

### DIFF
--- a/accounts/templates/accounts/staff_list.html
+++ b/accounts/templates/accounts/staff_list.html
@@ -34,7 +34,8 @@
                 {% endfor %}
             </div>
         {% endif %}
-        <div class="bg-white shadow-md rounded-lg overflow-hidden">
+
+        <div class="bg-white shadow-md rounded-lg overflow-x-auto">
             <table class="min-w-full divide-y divide-gray-200">
                 <thead class="bg-teal-50">
                     <tr>


### PR DESCRIPTION
close #133

## 背景
スマートフォンなどの画面幅が狭いデバイスでスタッフ管理画面を開いた際、テーブルの右側（店舗列・操作列）が画面外にはみ出して表示されないバグを修正しました。

## やったこと
* `accounts/templates/accounts/staff_list.html` の修正
    * テーブルを囲む `div` 要素に `overflow-x-auto` クラスを追加。
    * これにより、画面幅を超える場合に横スクロールが可能になり、全項目にアクセスできるようになりました。

## 動作確認方法
1. スマートフォン実機、またはブラウザのデベロッパーツールでスタッフ管理画面を開く。
2. 横にスワイプすることで「店舗」および「編集」ボタンが表示・操作できることを確認。