### PR TITLE
[add]掲示板に人気順並び替え機能

### DIFF
--- a/bbs/templates/bbs/list.html
+++ b/bbs/templates/bbs/list.html
@@ -6,7 +6,6 @@
 {% block content %}
 <div class="min-h-screen bg-[#b9cfcc] relative overflow-hidden pb-44">
 
-  <!-- 背景：控えめ（紙感＋薄いグラデ） -->
   <div class="absolute inset-0 pointer-events-none">
     <div class="absolute inset-0 bg-gradient-to-b from-white/10 via-transparent to-black/5"></div>
     <div class="absolute inset-0 opacity-[0.045]"
@@ -14,7 +13,6 @@
                 background-size: 14px 14px;"></div>
   </div>
 
-  <!-- 装飾：少なめ（角に薄い波紋1〜2個だけ） -->
   <div class="absolute inset-0 pointer-events-none z-0">
     <div class="absolute left-6 top-16 w-28 h-28 rounded-full border border-white/18"></div>
     <div class="absolute right-8 bottom-28 w-36 h-36 rounded-full border border-white/12"></div>
@@ -22,7 +20,6 @@
 
   <div class="relative z-10 max-w-6xl mx-auto px-4 pt-8">
 
-    <!-- ヘッダー -->
     <div class="flex items-start justify-between gap-4">
       <div>
         <h1 class="text-2xl sm:text-3xl font-bold text-[#2f2f2f] tracking-wide">掲示板</h1>
@@ -37,11 +34,9 @@
       </a>
     </div>
 
-    <!-- 検索＆フィルタ -->
     <div class="mt-6 bg-white/75 border border-white/70 rounded-2xl shadow-[0_14px_30px_rgba(0,0,0,0.12)]">
       <form method="get" action="" class="p-4 sm:p-5 space-y-3">
 
-        <!-- キーワード -->
         <div class="flex gap-2">
           <div class="flex-1">
             <input type="text" name="query" value="{{ query|default:'' }}"
@@ -56,7 +51,6 @@
           </button>
         </div>
 
-        <!-- フィルタ -->
         <div class="grid grid-cols-2 sm:grid-cols-3 gap-2 sm:max-w-3xl">
           <div class="relative">
             <select name="genre" onchange="this.form.submit()"
@@ -100,6 +94,7 @@
                            focus:outline-none focus:ring-2 focus:ring-black/10 text-[#2f2f2f]">
               <option value="newest" {% if sort == 'newest' %}selected{% endif %}>新しい順</option>
               <option value="oldest" {% if sort == 'oldest' %}selected{% endif %}>古い順</option>
+              <option value="popular" {% if sort == 'popular' %}selected{% endif %}>人気順</option>
             </select>
             <div class="pointer-events-none absolute inset-y-0 right-0 flex items-center px-3 text-[#2f2f2f]/60">
               <svg class="h-4 w-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
@@ -112,7 +107,6 @@
       </form>
     </div>
 
-    <!-- メッセージ -->
     {% if messages %}
       <div class="mt-5 space-y-3">
         {% for message in messages %}
@@ -127,7 +121,6 @@
       </div>
     {% endif %}
 
-    <!-- 投稿一覧 -->
     <div class="mt-6">
       {% if posts %}
         <div class="space-y-3">
@@ -138,7 +131,6 @@
                       transition overflow-hidden">
 
               <div class="p-4 sm:p-5">
-                <!-- 上：ジャンル＋日時 -->
                 <div class="flex items-center justify-between gap-3">
                   <span class="inline-flex items-center gap-2 text-xs font-bold px-3 py-1 rounded-full
                                bg-black/5 text-[#2f2f2f]/80 border border-black/10">
@@ -150,20 +142,16 @@
                   </span>
                 </div>
 
-                <!-- タイトル -->
                 <h2 class="mt-3 text-lg sm:text-xl font-bold text-[#2f2f2f] group-hover:opacity-90 transition">
                   {{ post.title }}
                 </h2>
 
-                <!-- 本文プレビュー -->
                 <p class="mt-2 text-sm text-[#2f2f2f]/80 line-clamp-2">
                   {{ post.body|default:post.content|truncatechars:80 }}
                 </p>
 
-                <!-- 下：メタ情報 -->
                 <div class="mt-4 flex flex-wrap items-center justify-between gap-3 text-xs text-[#2f2f2f]/65">
                   <div class="flex flex-wrap items-center gap-x-4 gap-y-2">
-                    <!-- ユーザー -->
                     <div class="inline-flex items-center gap-1">
                       <svg class="w-4 h-4 text-[#2f2f2f]/55" viewBox="0 0 24 24" fill="none">
                         <path d="M20 21a8 8 0 1 0-16 0" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"/>
@@ -172,7 +160,6 @@
                       <span>{{ post.user.username }}</span>
                     </div>
 
-                    <!-- 店舗（シンプルアイコン） -->
                     <div class="inline-flex items-center gap-1">
                       <svg class="w-4 h-4 text-[#2f2f2f]/55" viewBox="0 0 24 24" fill="none">
                         <path d="M4 10l2-6h12l2 6" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"/>
@@ -182,7 +169,6 @@
                       <span>{{ post.store.store_name }}</span>
                     </div>
 
-                    <!-- コメント数 -->
                     <div class="inline-flex items-center gap-1">
                       <svg class="w-4 h-4 text-[#2f2f2f]/55" viewBox="0 0 24 24" fill="none">
                         <path d="M21 12c0 4.4-4 8-9 8-1.3 0-2.6-.2-3.7-.6L3 20l1.3-4.1C3.5 14.8 3 13.4 3 12c0-4.4 4-8 9-8s9 3.6 9 8Z"
@@ -203,7 +189,6 @@
                     {% endif %}
                   </div>
 
-                  <!-- リアクション（シンプルアイコン） -->
                   <div class="flex gap-2">
                     <button type="button"
                       onclick="toggleReaction(event, 'post', {{ post.post_id }}, 'naruhodo')"
@@ -255,30 +240,30 @@
             {% if posts.has_previous %}
               <a href="?page=1{% if query_string %}&{{ query_string }}{% endif %}"
                 class="px-3 py-1.5 rounded-lg text-sm font-bold
-                        text-[#2f2f2f]/70 hover:bg-black/5 transition">
+                       text-[#2f2f2f]/70 hover:bg-black/5 transition">
                 «
               </a>
               <a href="?page={{ posts.previous_page_number }}{% if query_string %}&{{ query_string }}{% endif %}"
                 class="px-3 py-1.5 rounded-lg text-sm font-bold
-                        text-[#2f2f2f]/70 hover:bg-black/5 transition">
+                       text-[#2f2f2f]/70 hover:bg-black/5 transition">
                 ‹
               </a>
             {% endif %}
 
             <span class="px-4 py-1.5 rounded-lg text-sm font-bold
-                        bg-[#2f2f2f] text-white">
+                         bg-[#2f2f2f] text-white">
               {{ posts.number }} / {{ posts.paginator.num_pages }}
             </span>
 
             {% if posts.has_next %}
               <a href="?page={{ posts.next_page_number }}{% if query_string %}&{{ query_string }}{% endif %}"
                 class="px-3 py-1.5 rounded-lg text-sm font-bold
-                        text-[#2f2f2f]/70 hover:bg-black/5 transition">
+                       text-[#2f2f2f]/70 hover:bg-black/5 transition">
                 ›
               </a>
               <a href="?page={{ posts.paginator.num_pages }}{% if query_string %}&{{ query_string }}{% endif %}"
                 class="px-3 py-1.5 rounded-lg text-sm font-bold
-                        text-[#2f2f2f]/70 hover:bg-black/5 transition">
+                       text-[#2f2f2f]/70 hover:bg-black/5 transition">
                 »
               </a>
             {% endif %}


### PR DESCRIPTION
## 背景
これまで掲示板の並び替えは「新しい順」「古い順」のみでしたが、ユーザーからの反応（リアクション）が多い投稿を見つけやすくするため、並び替えの選択肢を拡充する必要がありました。

## やったこと
* **バックエンド (`board/views.py`)**:
    * `bbs_list` ビューにて、各投稿に対する「いいね」と「なるほど」のリアクション総数を計算する `total_reactions` を `annotate` で追加。
    * ソート条件に `popular` を追加し、リアクション総数の降順（同数の場合は新しい順）で並び替えるロジックを実装。
* **フロントエンド (`board/templates/board/list.html`)**:
    * 並び替え用のセレクトボックスに「人気順」オプションを追加。

## 動作確認方法
1. 掲示板一覧画面を開く。
2. フィルタの並び替えプルダウンから「人気順」を選択する。
3. 「いいね」や「なるほど」の数が多い投稿が上位に表示されることを確認する。
4. ジャンルや店舗フィルタと組み合わせても正しく並び替わることを確認する。